### PR TITLE
fix(footer): correct URL path for knowledgebase links

### DIFF
--- a/apps/website/src/content/loaders/payload/getFooter.ts
+++ b/apps/website/src/content/loaders/payload/getFooter.ts
@@ -18,7 +18,7 @@ function linkToLinkSchema(navItems: Footer["columnOne"]): LinkSchema[] {
                 // If referemce is a page, not a knowledgebase, use the slug
                 // If it is a knowledgebase, use the slugWithGroup
                 if ("slugWithGroup" in reference) {
-                    href = reference.slugWithGroup ? `wissen/${reference.slugWithGroup}` : ""
+                    href = reference.slugWithGroup ? `/wissen/${reference.slugWithGroup}` : ""
                 } else {
                     href = reference.slug ? `/${reference.slug}` : ""
                 }


### PR DESCRIPTION
Update the footer link generation to include a leading slash for 
knowledgebase links. This ensures that the generated URLs are 
correctly formatted and function as intended across the website.